### PR TITLE
Support JSON acne bands and multi-type breakout capture

### DIFF
--- a/src/components/ChooseProfile.tsx
+++ b/src/components/ChooseProfile.tsx
@@ -2,19 +2,7 @@ import { useEffect, useState } from 'react'
 import { getFillingQueue, getSessionProfile } from '../services/newConsultationService'
 import UpdatedConsultForm from './UpdatedConsultForm'
 import { User, Search, Clock, ArrowRight, Phone, Calendar } from 'lucide-react'
-
-type Band = 'green'|'blue'|'yellow'|'red'
-
-type MachineScanBands = {
-  moisture?: Band
-  sebum?: Band
-  texture?: Band
-  pores?: Band
-  acne?: Band
-  pigmentation_brown?: Band
-  pigmentation_red?: Band
-  sensitivity?: Band
-}
+import type { MachineScanBands } from '../lib/decisionEngine'
 
 export default function ChooseProfile({ onBack }: { onBack: () => void }) {
   const [queue, setQueue] = useState<any[]>([])
@@ -148,6 +136,7 @@ export default function ChooseProfile({ onBack }: { onBack: () => void }) {
                         texture: ma.texture_band,
                         pores: ma.pores_band,
                         acne: ma.acne_band,
+                        acneDetails: ma.acne_details ?? undefined,
                         // split UV/brown/red:
                         // - Brown maps from brown_areas_band when present, else fall back to pigmentation_uv_band
                         // - Red (PIE) mapped from redness_band when available (documented proxy)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,15 @@
+export type AcneCategory =
+  | 'Comedonal acne'
+  | 'Inflammatory acne'
+  | 'Cystic acne'
+  | 'Hormonal acne';
+
+export interface AcneBreakoutDetail {
+  type: string;
+  severity: string;
+  category: AcneCategory;
+}
+
 export interface UpdatedConsultData {
   // Personal Information  
   name: string;
@@ -25,9 +37,7 @@ export interface UpdatedConsultData {
   
   // Section D – Main Concerns
   mainConcerns: string[];
-  acneType: string;
-  acneSeverity: string;
-  acneCategory: string;
+  acneBreakouts: AcneBreakoutDetail[];
   acneDuration: string;
   pigmentationType: string;
   pigmentationSeverity: string;


### PR DESCRIPTION
## Summary
- model acne form answers as structured breakout details with categories, update the consultation form UI for multi-select selection, and surface machine-provided acne detail rows in the dev panel
- extend decision engine types and logic to parse structured acne readings, derive categories, and support JSON acne bands from Supabase
- normalize acne JSON payloads when fetching machine analysis data and propagate the parsed details through ChooseProfile

## Testing
- npm run build
- npm run lint *(fails: repo contains numerous existing `any`/unused symbol lint violations outside these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7553cca08322bf875dbb180e18ab